### PR TITLE
job command: Add option --from-test-number.

### DIFF
--- a/arc/cli/actions/job.py
+++ b/arc/cli/actions/job.py
@@ -13,6 +13,7 @@ import arc.cli.actions.base
 import arc.job
 import arc.tko.job
 import arc.host
+import arc.test
 
 
 OBJ_NAME = "job"
@@ -39,7 +40,13 @@ def add(app):
     machines = app.parsed_arguments.machines
     hosts, meta_hosts = arc.host.parse_specification(app.connection, machines)
 
-    control_file = app.parsed_arguments.control_file
+    if app.parsed_arguments.from_test_number:
+        content = arc.test.get_control_file_by_id(app.connection,
+                                                  app.parsed_arguments.from_test_number)
+        control_file = open(create_control_file(content))
+
+    if app.parsed_arguments.control_file:
+        control_file = app.parsed_arguments.control_file
 
     # Open the Control File in vi or $EDITOR
     if app.parsed_arguments.edit_before_sending is True:
@@ -84,6 +91,12 @@ def edit_control_file(control_file):
     os.system(editor + ' ' + new_control_file)
     control_file = open(new_control_file)
     return control_file
+
+def create_control_file(content):
+    fd, new_control_file = tempfile.mkstemp(prefix='control')
+    with open(new_control_file, 'w') as f:
+        f.write(content)
+    return new_control_file
 
 def print_job(connection, job_id, show_all=False):
     job = arc.job.get_data_by_id(connection, job_id)

--- a/arc/cli/args/job.py
+++ b/arc/cli/args/job.py
@@ -97,6 +97,12 @@ ARG_RUNNING = (('--all',),
                 'action': 'store_true',
                 'default': False})
 
+ARG_FROM_TEST = (('-T', '--from-test-number'),
+                 {'help': ('Add (create) a new job using the control file'
+                  'from a test registered on the autotest server'),
+                  'type': int,
+                  'metavar': 'TEST_ID'})
+
 ARG_EDIT_BEFORE = (('-E', '--edit-before-sending', ),
                    {'help': ('Open control file in editor before sending '
                              'the control file to the server.'),
@@ -146,4 +152,5 @@ ARGUMENTS = [arc.cli.args.base.NAME,
              ARG_REBOOT_BEFORE,
              ARG_REBOOT_AFTER,
              ARG_RUNNING,
+             ARG_FROM_TEST,
              ARG_EDIT_BEFORE]

--- a/arc/test.py
+++ b/arc/test.py
@@ -9,6 +9,7 @@ __all__ = ['get_data',
            'get_ids_names',
            'get_data_by_id',
            'get_data_by_name',
+           'get_control_file_by_id',
            'add',
            'delete',
            'modify',
@@ -41,6 +42,7 @@ GET_METHOD = 'get_tests'
 ADD_METHOD = 'add_test'
 DELETE_METHOD = 'delete_test'
 MODIFY_METHOD = 'modify_test'
+CONTROL_FILE_METHOD = 'generate_control_file'
 
 
 #
@@ -75,6 +77,18 @@ def modify(connection, identification, **data):
     """
     return connection.run(SERVICE_NAME, MODIFY_METHOD, identification, **data)
 
+
+def get_control_file_by_id(connection, identification):
+    """
+    Get Control File for a test by passing its identification.
+
+    :param connection: an instance of connection
+    :param identification: a test identification
+    :returns: the Control File (script) for the test
+    """
+    test = connection.run(SERVICE_NAME, CONTROL_FILE_METHOD,
+                          tests=(identification,))
+    return test['control_file']
 
 class Test(arc.base.Model):
     """


### PR DESCRIPTION
Add option --from-test-number to allow create a job from a test
registered on the autotest server. This implementation does not requires changes in autotest Server.

Example:

```
./scripts/arcli test --list | grep 'Sleeptest'
4   Server Sleeptest
57  Sleeptest
./scripts/arcli job --add --name t57 --machine vm-fedora \
                    --from-test-number 57
```

Signed-off-by: Ruda Moura rmoura@redhat.com
