### PR TITLE
Username login

### DIFF
--- a/arc/cli/app.py
+++ b/arc/cli/app.py
@@ -105,11 +105,15 @@ class App(object):
         if self.connection is not None:
             self.log.debug("Connection is already initialized")
         else:
+            if hasattr(self.parsed_arguments, "username"):
+                u = self.parsed_arguments.username
+            else:
+                u = None
             if hasattr(self.parsed_arguments, "host"):
                 h = self.parsed_arguments.host
                 self.log.debug("Connecting to: %s", h)
                 try:
-                    self.connection = arc.connection.Connection(h)
+                    self.connection = arc.connection.Connection(h, username=u)
                 except arc.connection.InvalidServiceVersionError:
                     self.log.error("The RPC interface version on the connected "
                                    "server is more recent than this version of "

--- a/arc/cli/args/parser.py
+++ b/arc/cli/args/parser.py
@@ -125,6 +125,15 @@ class Parser(argparse.ArgumentParser):
             config_section='server',
             config_key='host'
             )
+        server_group.add_argument(
+            '--username',
+            help=('Username to login in autotest server'),
+            action=arc.cli.args.actions.ConfigDefaultAction,
+            config=self.config,
+            config_section='server',
+            config_key='username'
+            )
+
 
     def add_arguments_on_all_modules(self,
                                      prefix=arc.defaults.ARGS_MODULE_PREFIX):

--- a/arc/config.py
+++ b/arc/config.py
@@ -10,6 +10,7 @@ system wide configuration file.
 
 
 import os
+import getpass
 
 import arc.defaults
 
@@ -87,6 +88,18 @@ class UserLocalConfigParser(configparser.ConfigParser):
         if not value:
             value = arc.defaults.SERVER_PORT
 
+        return value
+
+    def get_username(self):
+        """
+        Returns the username to login
+        """
+        if os.environ.has_key('ARC_USER'):
+            value = os.environ['ARC_USER']
+        elif self.has_option('server', 'username'):
+            value = self.get('server', 'username')
+        else:
+            value = getpass.getuser()
         return value
 
 

--- a/arc/connection.py
+++ b/arc/connection.py
@@ -172,7 +172,7 @@ class Connection(BaseConnection):
     :param port: the port number where the RPC server is running
     """
     def __init__(self, hostname=None, port=None, username=None):
-        super(Connection, self).__init__(hostname, port, username)
+        super(Connection, self).__init__(hostname, port, username=username)
         for (name, path) in arc.shared.rpc.PATHS.items():
             self.add_service(name, path)
 

--- a/arc/proxy.py
+++ b/arc/proxy.py
@@ -30,14 +30,17 @@ class Proxy(object):
     """
     Service proxy to a JSON RPC Server
     """
-    def __init__(self, uri):
+    def __init__(self, uri, headers={}):
         """
         Initializes a new proxy
 
         :param uri: the complete URI for the JSON RPC Server
         :type uri: str
+        :param headers: the headers to pass to the request
+        :type headers: dict
         """
         self.uri = uri
+        self.headers = headers
 
     def __getattr__(self, name):
         """
@@ -48,14 +51,14 @@ class Proxy(object):
         :returns: a method wrapper instance
         :rtype: :class:`Method`
         """
-        return Method(self.uri, name)
+        return Method(self.uri, self.headers, name)
 
 
 class Method(object):
     """
     Class that wrapps an RPC Server Method
     """
-    def __init__(self, uri, name):
+    def __init__(self, uri, headers, name):
         """
         Initializes a new method
 
@@ -65,6 +68,7 @@ class Method(object):
         :type name: str
         """
         self.uri = uri
+        self.headers = headers
         self.name = name
 
     @staticmethod
@@ -106,7 +110,7 @@ class Method(object):
 
         # Send the request
         post = self.encode(post)
-        request = Request(self.uri, data=post)
+        request = Request(self.uri, data=post, headers=self.headers)
 
         # Receive the response
         response = urlopen(request).read()


### PR DESCRIPTION
Allow to specify an username to login when interacting with Autotest Server.
The username is defined by using option `--username`, environment variable `ARC_USER` or in the configuration file, option `username` in section `server`.

Note that If no username is passed, the username will be guessed, so the use of this option is rare.
